### PR TITLE
feat(vercel): setup analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { Inter as FontMono } from "next/font/google"
 import localFont from "next/font/local"
 import { Analytics } from "@vercel/analytics/next"
@@ -9,8 +10,6 @@ import { Header } from "@/components/header"
 import { ThemeProvider } from "@/components/theme-provider"
 
 import "@/styles/global.css"
-
-import { Metadata } from "next/types"
 
 const fontHeading = localFont({
   src: "../assets/fonts/CalSans-SemiBold.woff2",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,16 @@
 import { Inter as FontMono } from "next/font/google"
 import localFont from "next/font/local"
+import { Analytics } from "@vercel/analytics/next"
 
 import { siteConfig } from "@/lib/config"
 import { cn } from "@/lib/utils"
-import { Analytics } from "@/components/analytics"
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { ThemeProvider } from "@/components/theme-provider"
 
 import "@/styles/global.css"
+
+import { Metadata } from "next/types"
 
 const fontHeading = localFont({
   src: "../assets/fonts/CalSans-SemiBold.woff2",
@@ -19,7 +21,7 @@ const fontMono = FontMono({
   variable: "--font-mono",
 })
 
-export const metadata = {
+export const metadata: Metadata = {
   metadataBase: new URL(siteConfig.url),
   title: {
     default: "Christopher Cardoso",

--- a/components/analytics.tsx
+++ b/components/analytics.tsx
@@ -1,7 +1,0 @@
-"use client"
-
-import { Analytics as VercelAnalytics } from "@vercel/analytics/react"
-
-export function Analytics() {
-  return <VercelAnalytics />
-}


### PR DESCRIPTION
## Summary
- switch analytics to `@vercel/analytics/next` in the root layout
- remove the custom client analytics wrapper
- add an explicit `Metadata` type for layout metadata

## Testing
- Not run (PR creation only)