### PR TITLE
feat(nav): add projects link to header

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -10,6 +10,7 @@ import { ThemeSwitch } from "./theme-switch"
 const headerNavLinks: { href: Route; title: string }[] = [
   { href: "/about", title: "About" },
   { href: "/blog", title: "Blog" },
+  { href: "/projects", title: "Projects" },
   { href: "/uses", title: "Uses" },
 ]
 


### PR DESCRIPTION
Adds /projects to the header nav now that the page renders the projects list (follow-up to #59).