### PR TITLE
Refactor app architecture boundaries

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,24 +1,13 @@
-import { ViewTransition } from "react"
-import type { Metadata, Route } from "next"
-import Link from "next/link"
+import { Suspense } from "react"
+import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { siteConfig } from "@/lib/config"
-import { calculateReadingTime } from "@/lib/reading-time"
 import {
-  createBlogHref,
-  DraftBadge,
-} from "@/features/post/components/blog-index"
-import { SeriesNav } from "@/features/post/components/series-nav"
-import {
-  formatPostDate,
-  getAllPosts,
-  getPostBySlug,
-  getPostTags,
-  getSeriesPosts,
-} from "@/features/post/post-queries"
-import { MDXContent } from "@/components/mdx-components"
-import MdxLayout from "@/components/mdx-layout"
+  PostDetail,
+  PostDetailSkeleton,
+} from "@/features/post/components/post-detail"
+import { getAllPosts, getPostBySlug } from "@/features/post/post-queries"
 
 export const dynamicParams = false
 
@@ -71,75 +60,11 @@ export const generateMetadata = async (
 }
 
 export default function PostPage({ params }: PageProps<"/blog/[slug]">) {
-  return params.then(({ slug }) => {
-    const post = getPostBySlug(slug)
-    if (!post) notFound()
-
-    const readingTime = calculateReadingTime(post.content)
-    const tags = getPostTags(post.tag)
-    const seriesPosts = post.series
-      ? getSeriesPosts(post.series, post.draft)
-      : []
-    const currentSeriesIndex = seriesPosts.findIndex(
-      (seriesPost) => seriesPost.slug === post.slug
-    )
-
-    return (
-      <article className="mx-auto max-w-4xl py-8 md:py-12">
-        <Link
-          href="/blog"
-          className="mb-8 inline-flex min-h-touch items-center rounded-lg text-sm text-gray-600 transition-colors hover:text-purple-700 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-purple-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-lightGray dark:text-gray-400 dark:hover:text-purple-300 dark:focus-visible:ring-offset-dark md:mb-10"
-        >
-          Back to articles
-        </Link>
-
-        <header className="mb-8 max-w-3xl md:mb-10">
-          <p className="font-mono text-xs text-gray-500 dark:text-gray-400">
-            <time dateTime={post.date}>{formatPostDate(post.date)}</time>
-            {" · "}
-            {readingTime} min read
-            {post.draft && <DraftBadge />}
-          </p>
-          <ViewTransition
-            name={`post-title-${slug}`}
-            share="text-morph"
-            default="none"
-          >
-            <h1 className="mt-4 text-balance font-heading text-[2rem] font-bold leading-tight tracking-tight text-gray-900 dark:text-ctp-text md:text-5xl">
-              {post.title}
-            </h1>
-          </ViewTransition>
-          <p className="mt-4 max-w-prose text-base leading-relaxed text-gray-600 dark:text-gray-400 md:text-lg">
-            {post.summary}
-          </p>
-          <div className="mt-5 flex flex-wrap gap-2">
-            {tags.map((tag) => (
-              <Link
-                key={tag}
-                href={createBlogHref({ tag })}
-                className="rounded-full border border-purple-500/40 px-3 py-1 text-sm text-purple-700 transition-colors hover:border-purple-500 hover:bg-purple-500/10 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-purple-500/70 dark:border-purple-300/40 dark:text-purple-300 dark:hover:border-purple-300 dark:hover:bg-purple-300/10"
-              >
-                {tag}
-              </Link>
-            ))}
-          </div>
-        </header>
-
-        {post.series && currentSeriesIndex !== -1 && seriesPosts.length > 1 && (
-          <SeriesNav
-            series={post.series}
-            current={currentSeriesIndex + 1}
-            parts={seriesPosts.map((seriesPost) => ({
-              title: seriesPost.title,
-              href: `/blog/${seriesPost.slug}` as Route,
-            }))}
-          />
-        )}
-
-        <MdxLayout>
-          <MDXContent source={post.content} />
-        </MdxLayout>
-      </article>
-    )
-  })
+  return (
+    <Suspense fallback={<PostDetailSkeleton />}>
+      {params.then(({ slug }) => (
+        <PostDetail slug={slug} />
+      ))}
+    </Suspense>
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import { PostsList } from "@/features/post/components/posts-list"
 import { PresentationBanner } from "@/components/presentation-banner"
-import { ProjectsList } from "@/components/projects-list"
+import { ProjectsSection } from "@/components/projects-list"
 
 export default function HomePage() {
   return (
@@ -9,7 +9,7 @@ export default function HomePage() {
       <div className="mt-10 grid gap-10 lg:grid-cols-[minmax(0,1fr)_24rem] lg:items-start lg:gap-8 xl:gap-10">
         <PostsList />
         <div className="lg:sticky lg:top-8">
-          <ProjectsList />
+          <ProjectsSection />
         </div>
       </div>
     </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -38,7 +38,9 @@ export default function Projects() {
         experiments. Some are practical, some are just for fun, all are things I
         wanted to build.
       </PageHeader>
-      <ProjectsList hideHeading />
+      <section id="projects">
+        <ProjectsList />
+      </section>
     </div>
   )
 }

--- a/app/uses/page.tsx
+++ b/app/uses/page.tsx
@@ -245,6 +245,7 @@ export default function Uses() {
           src="/images/uses/desk-setup.jpg"
           alt="Christopher Cardoso desk setup with monitors, laptop, and keyboard"
           aspectRatio="16:9"
+          priority
         />
 
         <section>

--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -6,6 +6,7 @@ interface BannerProps {
   src: string
   alt: string
   aspectRatio?: "auto" | "16:9" | "21:9" | "4:3"
+  priority?: boolean
 }
 
 const aspectRatioClass = {
@@ -14,7 +15,12 @@ const aspectRatioClass = {
   "4:3": "aspect-4/3",
 }
 
-export function Banner({ src, alt, aspectRatio = "auto" }: BannerProps) {
+export function Banner({
+  src,
+  alt,
+  aspectRatio = "auto",
+  priority = false,
+}: BannerProps) {
   const isAuto = aspectRatio === "auto"
 
   return (
@@ -34,7 +40,7 @@ export function Banner({ src, alt, aspectRatio = "auto" }: BannerProps) {
             sizes="(max-width: 768px) 100vw, 800px"
             className="m-0! block h-auto w-full rounded-xl"
             style={{ height: "auto" }}
-            priority
+            priority={priority}
           />
         ) : (
           <div
@@ -49,7 +55,7 @@ export function Banner({ src, alt, aspectRatio = "auto" }: BannerProps) {
               fill
               sizes="(max-width: 768px) 100vw, 800px"
               className="object-cover"
-              priority
+              priority={priority}
             />
           </div>
         )}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -8,13 +8,11 @@ import rehypePrettyCode from "rehype-pretty-code"
 import remarkGfm from "remark-gfm"
 
 import { cn } from "@/lib/utils"
-import { SeriesNav } from "@/features/post/components/series-nav"
 import { Banner } from "@/components/banner"
 import { Callout } from "@/components/callout"
 import { Code } from "@/components/code"
 import { MdxCard, MdxDisabledCard, MdxLinkCard } from "@/components/mdx-card"
 import { MdxImage } from "@/components/mdx-image"
-import { PluginCard } from "@/components/plugin-card"
 import { VideoEmbed } from "@/components/video-embed"
 
 const mdxOptions: MDXRemoteProps["options"] = {
@@ -254,8 +252,6 @@ const components = {
   MdxDisabledCard,
   MdxImage,
   MdxLinkCard,
-  PluginCard,
-  SeriesNav,
   StaticTweet,
   VideoEmbed,
 } satisfies MDXComponents

--- a/components/projects-list.tsx
+++ b/components/projects-list.tsx
@@ -27,10 +27,6 @@ function ProjectCard({ project }: { project: Project }) {
       <p className="mt-4 max-w-[62ch] text-base leading-relaxed text-gray-600 dark:text-gray-400">
         {project.description}
       </p>
-
-      <p className="mt-4 font-mono text-xs leading-relaxed text-gray-500 dark:text-gray-400">
-        {project.details.join(" / ")}
-      </p>
     </Link>
   )
 }

--- a/components/projects-list.tsx
+++ b/components/projects-list.tsx
@@ -1,11 +1,7 @@
 import Link from "next/link"
 import { projects, type Project } from "@/data/projects"
 
-import { ArrowIcon } from "./icons"
-
-interface ProjectListProps {
-  hideHeading?: boolean
-}
+import { ArrowIcon } from "@/components/icons"
 
 function ProjectCard({ project }: { project: Project }) {
   return (
@@ -39,26 +35,32 @@ function ProjectCard({ project }: { project: Project }) {
   )
 }
 
-export function ProjectsList({ hideHeading }: ProjectListProps) {
+export function ProjectsList() {
+  if (projects.length <= 0) return null
+
+  return (
+    <div className="divide-y divide-gray-200/80 border-b border-gray-200/80 dark:divide-ctp-surface0/80 dark:border-ctp-surface0/80">
+      {projects.map((project) => (
+        <ProjectCard key={project.href} project={project} />
+      ))}
+    </div>
+  )
+}
+
+export function ProjectsSection() {
   if (projects.length <= 0) return null
 
   return (
     <section id="projects">
-      {hideHeading ? null : (
-        <div className="mb-6 max-w-2xl">
-          <h2 className="font-heading text-3xl tracking-tight text-gray-950 dark:text-ctp-text md:text-4xl">
-            Projects
-          </h2>
-          <p className="mt-3 text-base leading-relaxed text-gray-600 dark:text-gray-400">
-            A tighter look at the tools and spaces I am shaping outside of work.
-          </p>
-        </div>
-      )}
-      <div className="divide-y divide-gray-200/80 border-b border-gray-200/80 dark:divide-ctp-surface0/80 dark:border-ctp-surface0/80">
-        {projects.map((project) => (
-          <ProjectCard key={project.href} project={project} />
-        ))}
+      <div className="mb-6 max-w-2xl">
+        <h2 className="font-heading text-3xl tracking-tight text-gray-950 dark:text-ctp-text md:text-4xl">
+          Projects
+        </h2>
+        <p className="mt-3 text-base leading-relaxed text-gray-600 dark:text-gray-400">
+          A tighter look at the tools and spaces I am shaping outside of work.
+        </p>
       </div>
+      <ProjectsList />
     </section>
   )
 }

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -3,7 +3,6 @@ export interface Project {
   description: string
   href: `https://${string}`
   focus: string
-  details: string[]
 }
 
 export const projects: Project[] = [
@@ -12,7 +11,6 @@ export const projects: Project[] = [
     description:
       "A developer tool for turning a project idea into a usable README draft without starting from a blank file.",
     focus: "Developer tooling",
-    details: ["README generation", "Public build log", "Open source repo"],
     href: "https://github.com/kriscard/readme-ai",
   },
   {
@@ -20,7 +18,6 @@ export const projects: Project[] = [
     description:
       "The site you are reading now, built as a small Next.js system for MDX writing, project notes, and a Catppuccin theme.",
     focus: "Personal site",
-    details: ["Next.js App Router", "MDX blog", "View transitions"],
     href: "https://github.com/kriscard/christophercardoso.dev",
   },
 ]

--- a/features/post/components/blog-index.tsx
+++ b/features/post/components/blog-index.tsx
@@ -219,14 +219,14 @@ export function DraftBadge() {
   )
 }
 
-export function PostListItem({
+function PostRow({
   post,
-  titleAs: TitleComponent = "h2",
-  dense = false,
+  title: TitleComponent,
+  linkClassName,
 }: {
   post: Post
-  titleAs?: "h2" | "h3"
-  dense?: boolean
+  title: "h2" | "h3"
+  linkClassName: string
 }) {
   return (
     <article>
@@ -234,7 +234,7 @@ export function PostListItem({
         href={`/blog/${post._meta.path}`}
         className={cn(
           "group block cursor-pointer rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-purple-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-lightGray dark:focus-visible:ring-offset-dark",
-          dense ? "py-5" : "px-4 py-5"
+          linkClassName
         )}
         aria-label={`Read ${post.title}`}
       >
@@ -260,6 +260,14 @@ export function PostListItem({
       </Link>
     </article>
   )
+}
+
+export function BlogPostListItem({ post }: { post: Post }) {
+  return <PostRow post={post} title="h2" linkClassName="px-4 py-5" />
+}
+
+export function RecentPostListItem({ post }: { post: Post }) {
+  return <PostRow post={post} title="h3" linkClassName="py-5" />
 }
 
 function LatestPost({ post }: { post: Post }) {
@@ -367,7 +375,7 @@ export function BlogIndex({
           ) : null}
           <div className="space-y-1">
             {listPosts.map((post) => (
-              <PostListItem key={post._meta.path} post={post} />
+              <BlogPostListItem key={post._meta.path} post={post} />
             ))}
           </div>
         </>

--- a/features/post/components/post-detail.tsx
+++ b/features/post/components/post-detail.tsx
@@ -1,0 +1,111 @@
+import { ViewTransition } from "react"
+import type { Route } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+
+import { calculateReadingTime } from "@/lib/reading-time"
+import {
+  createBlogHref,
+  DraftBadge,
+} from "@/features/post/components/blog-index"
+import { SeriesNav } from "@/features/post/components/series-nav"
+import {
+  formatPostDate,
+  getPostBySlug,
+  getPostTags,
+  getSeriesPosts,
+} from "@/features/post/post-queries"
+import { MDXContent } from "@/components/mdx-components"
+import MdxLayout from "@/components/mdx-layout"
+
+export function PostDetail({ slug }: { slug: string }) {
+  const post = getPostBySlug(slug)
+  if (!post) notFound()
+
+  const readingTime = calculateReadingTime(post.content)
+  const tags = getPostTags(post.tag)
+  const seriesPosts = post.series ? getSeriesPosts(post.series, post.draft) : []
+  const currentSeriesIndex = seriesPosts.findIndex(
+    (seriesPost) => seriesPost.slug === post.slug
+  )
+
+  return (
+    <article className="mx-auto max-w-4xl py-8 md:py-12">
+      <Link
+        href="/blog"
+        className="mb-8 inline-flex min-h-touch items-center rounded-lg text-sm text-gray-600 transition-colors hover:text-purple-700 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-purple-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-lightGray dark:text-gray-400 dark:hover:text-purple-300 dark:focus-visible:ring-offset-dark md:mb-10"
+      >
+        Back to articles
+      </Link>
+
+      <header className="mb-8 max-w-3xl md:mb-10">
+        <p className="font-mono text-xs text-gray-500 dark:text-gray-400">
+          <time dateTime={post.date}>{formatPostDate(post.date)}</time>
+          {" · "}
+          {readingTime} min read
+          {post.draft && <DraftBadge />}
+        </p>
+        <ViewTransition
+          name={`post-title-${slug}`}
+          share="text-morph"
+          default="none"
+        >
+          <h1 className="mt-4 text-balance font-heading text-[2rem] font-bold leading-tight tracking-tight text-gray-900 dark:text-ctp-text md:text-5xl">
+            {post.title}
+          </h1>
+        </ViewTransition>
+        <p className="mt-4 max-w-prose text-base leading-relaxed text-gray-600 dark:text-gray-400 md:text-lg">
+          {post.summary}
+        </p>
+        <div className="mt-5 flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <Link
+              key={tag}
+              href={createBlogHref({ tag })}
+              className="rounded-full border border-purple-500/40 px-3 py-1 text-sm text-purple-700 transition-colors hover:border-purple-500 hover:bg-purple-500/10 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-purple-500/70 dark:border-purple-300/40 dark:text-purple-300 dark:hover:border-purple-300 dark:hover:bg-purple-300/10"
+            >
+              {tag}
+            </Link>
+          ))}
+        </div>
+      </header>
+
+      {post.series && currentSeriesIndex !== -1 && seriesPosts.length > 1 && (
+        <SeriesNav
+          series={post.series}
+          current={currentSeriesIndex + 1}
+          parts={seriesPosts.map((seriesPost) => ({
+            title: seriesPost.title,
+            href: `/blog/${seriesPost.slug}` as Route,
+          }))}
+        />
+      )}
+
+      <MdxLayout>
+        <MDXContent source={post.content} />
+      </MdxLayout>
+    </article>
+  )
+}
+
+export function PostDetailSkeleton() {
+  return (
+    <article className="mx-auto max-w-4xl py-8 md:py-12">
+      <div className="mb-8 h-5 w-28 rounded bg-gray-200/80 dark:bg-ctp-surface0/80 md:mb-10" />
+      <header className="mb-8 max-w-3xl md:mb-10">
+        <div className="h-4 w-40 rounded bg-gray-200/80 dark:bg-ctp-surface0/80" />
+        <div className="mt-4 h-10 w-full max-w-2xl rounded bg-gray-200/80 dark:bg-ctp-surface0/80 md:h-14" />
+        <div className="mt-3 h-10 w-full max-w-xl rounded bg-gray-200/80 dark:bg-ctp-surface0/80" />
+        <div className="mt-5 flex gap-2">
+          <div className="h-7 w-20 rounded-full bg-gray-200/80 dark:bg-ctp-surface0/80" />
+          <div className="h-7 w-24 rounded-full bg-gray-200/80 dark:bg-ctp-surface0/80" />
+        </div>
+      </header>
+      <div className="space-y-3">
+        <div className="h-4 w-full rounded bg-gray-200/80 dark:bg-ctp-surface0/80" />
+        <div className="h-4 w-11/12 rounded bg-gray-200/80 dark:bg-ctp-surface0/80" />
+        <div className="h-4 w-10/12 rounded bg-gray-200/80 dark:bg-ctp-surface0/80" />
+      </div>
+    </article>
+  )
+}

--- a/features/post/components/posts-list.tsx
+++ b/features/post/components/posts-list.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 
-import { PostListItem } from "@/features/post/components/blog-index"
+import { RecentPostListItem } from "@/features/post/components/blog-index"
 import { getAllPosts } from "@/features/post/post-queries"
 import { ArrowIcon } from "@/components/icons"
 
@@ -29,7 +29,7 @@ export function PostsList() {
       </div>
       <div className="divide-y divide-gray-200/80 dark:divide-ctp-surface0/80">
         {recentPosts.map((post) => (
-          <PostListItem key={post._meta.path} post={post} titleAs="h3" dense />
+          <RecentPostListItem key={post._meta.path} post={post} />
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Extract blog post detail rendering into a post feature component with a page-owned Suspense boundary and skeleton
- Trim unused MDX registry entries and preserve existing MDX content components
- Split project list rendering from homepage section chrome
- Make banner image priority opt-in and opt in the `/uses` hero banner
- Replace post list mode props with explicit blog/recent list item variants

## Validation

- `pnpm exec next typegen`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Notes

Generated audit artifacts were left untracked in the local worktree and are not included in this PR.
